### PR TITLE
Add upcoming tournaments section to homepage

### DIFF
--- a/client/src/components/upcoming-tournaments.tsx
+++ b/client/src/components/upcoming-tournaments.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Calendar, MapPin } from "lucide-react";
+import TournamentTimeDisplay from "@/components/tournament-time-display";
+
+interface TournamentSummary {
+  id: string;
+  name: string;
+  startDate: string;
+  location: string;
+  backgroundImage?: string | null;
+}
+
+function UpcomingTournaments() {
+  const { data: tournaments = [] } = useQuery<TournamentSummary[]>({
+    queryKey: ["/api/tournaments"],
+  });
+
+  const upcoming = tournaments
+    .filter(t => new Date(t.startDate) >= new Date())
+    .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+    .slice(0, 3);
+
+  if (upcoming.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {upcoming.map(t => (
+        <Link key={t.id} href={`/tournament/${t.id}`}>
+          <Card className="h-full hover:shadow-lg transition-shadow">
+            {t.backgroundImage && (
+              <div
+                className="h-32 w-full bg-cover bg-center"
+                style={{ backgroundImage: `url(${t.backgroundImage})` }}
+              />
+            )}
+            <CardHeader>
+              <CardTitle className="text-lg font-bold">{t.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex items-center">
+                <Calendar className="mr-2 h-4 w-4 text-mtta-green" />
+                <TournamentTimeDisplay startDate={t.startDate} />
+              </div>
+              <div className="flex items-center">
+                <MapPin className="mr-2 h-4 w-4 text-mtta-green" />
+                <span>{t.location}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export default UpcomingTournaments;
+

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -9,6 +9,7 @@ import { Users, Building, Trophy, Medal, Calendar, Award, ExternalLink } from "l
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import PageWithLoading from "@/components/PageWithLoading";
+import UpcomingTournaments from "@/components/upcoming-tournaments";
 
 // Type definitions for API responses
 interface SliderItem {
@@ -324,7 +325,15 @@ export default function Home() {
           </div>
         </div>
       )}
-      
+
+      {/* Upcoming Tournaments Section */}
+      <div className="py-8">
+        <div className="container mx-auto px-4">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">Ирэх тэмцээнүүд</h2>
+          <UpcomingTournaments />
+        </div>
+      </div>
+
       <div className="w-full px-4 sm:px-6 lg:px-8 py-8">
         {/* Welcome Section */}
         <div className="mb-8">


### PR DESCRIPTION
## Summary
- show upcoming tournaments on home page
- add component that lists next events from API

## Testing
- `npm run check` *(fails: server/storage.ts type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b74ea22ac8321a7fb5275d28c1a94